### PR TITLE
Test issue #24

### DIFF
--- a/packages/tcpserver/tcpserver.go
+++ b/packages/tcpserver/tcpserver.go
@@ -96,6 +96,8 @@ func (t *TcpServer) HandleTcpRequest() {
 		t.Type11()
 	case 12:
 		t.Type12()
+	case 14:
+		t.Type10()		
 	}
 	log.Debug("END")
 }


### PR DESCRIPTION
Тестовый вариант для issue 24. Касается блокирования Касперским однобайтных TCP пакетов с числами 10 (0xA) и 13 (0xD). В этом случае пакет до t.Type10() просто не доходит. Данное изменение не влияет на общение с текущими версиями клиентов - просьба обновить для pool.dcoin.club:8088. Я у себя в blocks_collection.go в строке 331 изменю 
dataTypeMaxBlockId = 10 на dataTypeMaxBlockId = 14 и посмотрим будет ли отваливаться read по таймауту или нет. По моим расчетам всё должно заработать.